### PR TITLE
Add licensing and copyright info

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,12 @@ This repository contains data about declarations made by donors to Australian po
 -	It was not possible to categorise all company donors. For some, there is little information publicly available. These are marked as 'uncategorised'.
 -	ABC News [published a story using this data](http://www.abc.net.au/news/2017-02-09/political-donations-industry-dataset/8229192).
 -	It was originally scraped from the Australian Electoral Commission's website on February 1, 2017 using [a scraper](https://github.com/drzax/AEC-scraper-donations-declared-by-donors) originally written by [Nick Evershed](https://github.com/nickjevershed).
+
+Copyright & License
+-------------------
+
+*© Commonwealth of Australia 2017 and Australian Broadcasting Corporation 2017*
+
+Both the original data (supplied by the Australian Electoral Commission) and any modifications or additions are licensed under the [Creative Commons Attribution 4.0 International License](https://creativecommons.org/licenses/by/4.0/).
+
+Code is MIT licensed.

--- a/scripts/LICENSE.txt
+++ b/scripts/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Australian Broadcasting Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Closes #2 

Adds CC-BY-4.0 license to the data (in line with the original license from AEC).

A separate licence is applied to code following Creative Commons' recommendation that their licenses aren't applied to software. MIT chosen for simplicity.